### PR TITLE
fix: show only a single column for the feature list on small screens

### DIFF
--- a/src/components/feature-list.svelte
+++ b/src/components/feature-list.svelte
@@ -1,7 +1,7 @@
 <div class="feature-list">
-    <div class="grid grid-rows-auto grid-cols-2 gap-4">
+    <div class="grid grid-rows-auto grid-cols-1 768:grid-cols-2 gap-4">
         {#each features as feature, i}
-            <div class="transition ease-in-out rounded-lg bg-feDarkBlue-600 border-2 border-transparent hover:bg-feDarkBlue-800 hover:border-sky-500 p-4 leading-relaxed text-base flex items-center">
+            <div class="transition ease-in-out rounded-lg bg-feDarkBlue-600 border-2 border-transparent hover:bg-feDarkBlue-800 hover:border-sky-500 p-4 leading-relaxed text-base">
                 {feature}
             </div>
         {/each}


### PR DESCRIPTION
Not much to explain here. Just fixes the feature list to show single columns on mobile.