### PR TITLE
Fixes nuget command documentation

### DIFF
--- a/src/routes/docs/[...13]integration-unit-testing.md
+++ b/src/routes/docs/[...13]integration-unit-testing.md
@@ -37,7 +37,7 @@ Follow the steps below to start WAF testing your endpoints:
 The examples below will use the following Nuget packages, they are recommendations but not strictly required. Install them in your test project.
 ```yaml | title=terminal | copy
 dotnet add package Bogus # used to generate realistic looking fake data
-dotnet add package FluentAssertings # used to write prettier assert statements
+dotnet add package FluentAssertions # used to write prettier assert statements
 dotnet add package Testcontainers # used to auto-start docker containers
 ```
 


### PR DESCRIPTION
**Fix**

This PR fixes a typo in the testing documentation page. It changes the package name FluentAssertings to the correct, FluentAssertions.