### PR TITLE
Search web worker

### DIFF
--- a/src/lib/search/client/search.ts
+++ b/src/lib/search/client/search.ts
@@ -7,13 +7,10 @@ const index = new Index<string>({ tokenize: 'forward' });
 const searchLookup = new Map<string, SearchResult>();
 
 export let isInited = false;
-export let isInitInProgess = false;
 
 
 export async function init(origin: string) {
     if (isInited) return;
-
-    isInitInProgess = true;
 
     const rsp = await fetch(`${origin}/search.json`);
     const searchData : SearchBlocks = await rsp.json();
@@ -31,7 +28,6 @@ export async function init(origin: string) {
         index.add(href, `${title} ${content}`);
     }
 
-    isInitInProgess = false;
     isInited = true;
 }
 

--- a/src/lib/search/client/store.ts
+++ b/src/lib/search/client/store.ts
@@ -19,7 +19,8 @@ function createSearchStore() {
     let worker : RequestWorker | null = null
 
 
-    if (browser) {
+    // only clientside in browsers which support WebWorkers
+    if (browser && window.Worker) {
         worker = new SearchWorker();
 
         worker.onmessage = (response) => {

--- a/src/lib/search/client/worker.ts
+++ b/src/lib/search/client/worker.ts
@@ -1,5 +1,6 @@
+/// <reference lib="webworker" />
 import type { SearchResult } from '../types';
-import { init, isInited, isInitInProgess, search } from './search';
+import { init, isInited, search } from './search';
 
 type InitRequest = {
     type: 'init';
@@ -23,49 +24,20 @@ type SearchResponse = {
 type RequestMessage = InitRequest | SearchRequest;
 type ResponseMessage = ReadyResponse | SearchResponse;
 
-// MessagePort with typed messages
-interface Port<TOnMsg,TPostMsg> extends EventTarget {
-    onmessage: ((this: Port<TOnMsg, TPostMsg>, ev: MessageEvent<TOnMsg>) => unknown) | null;
-    onmessageerror: ((this: MessagePort, ev: MessageEvent) => unknown) | null;
-    close(): void;
-    postMessage(message: TPostMsg, transfer: Transferable[]): void;
-    postMessage(message: TPostMsg, options?: StructuredSerializeOptions): void;
-    start(): void;
-    addEventListener<K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => unknown, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof MessagePortEventMap>(type: K, listener: (this: MessagePort, ev: MessagePortEventMap[K]) => unknown, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+export interface RequestWorker extends Worker {
+    onmessage: ((this: RequestWorker, ev: MessageEvent<ResponseMessage>) => unknown) | null;
+    postMessage(message: RequestMessage) : void;
 }
 
-// MessageEvent with typed messages
-interface OnConnectMessageEvent extends Event {
-    readonly data: never;
-    readonly lastEventId: string;
-    readonly origin: string;
-    readonly source: MessageEventSource | null;
-    readonly ports: ReadonlyArray<Port<RequestMessage, ResponseMessage>>;
-    /** @deprecated */
-    initMessageEvent(type: string, bubbles?: boolean, cancelable?: boolean, data?: unknown, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: MessagePort[]): void;
+interface ResponseWorker extends DedicatedWorkerGlobalScope {
+    onmessage: ((this: ResponseWorker, ev: MessageEvent<RequestMessage>) => unknown) | null;
+    postMessage(message: ResponseMessage) : void;
 }
 
-export type RequestWorker = {
-    port: Port<ResponseMessage, RequestMessage>,
-};
 
-type ResponseWorker = {
-    onconnect: ((this: SharedWorkerGlobalScope, ev: OnConnectMessageEvent) => unknown) | null;
-}
+const worker : ResponseWorker = self as unknown as ResponseWorker;
 
-const worker : ResponseWorker = self as SharedWorkerGlobalScope;
-worker.onconnect = handleConnect;
-
-function handleConnect(this: SharedWorkerGlobalScope, e: OnConnectMessageEvent) {
-    e.ports[0].onmessage = handleMessage;
-}
-
-let portsWaitingOnInit : Port<RequestMessage, ResponseMessage>[] = [];
-
-async function handleMessage(this: Port<RequestMessage, ResponseMessage>, request: MessageEvent<RequestMessage>) {
+worker.onmessage = async function(request) {
     const msg = request.data;
 
     switch (msg.type) {
@@ -75,20 +47,8 @@ async function handleMessage(this: Port<RequestMessage, ResponseMessage>, reques
                 break;
             }
 
-            portsWaitingOnInit.push(this);
-
-            if (isInitInProgess) {
-                break;
-            }
-
             await init(msg.origin);
-
-            for(const port of portsWaitingOnInit) {
-                port.postMessage({ type: 'ready' });
-            }
-
-            portsWaitingOnInit = [];
-
+            this.postMessage({ type: 'ready' });
 
             break;
         }
@@ -100,9 +60,6 @@ async function handleMessage(this: Port<RequestMessage, ResponseMessage>, reques
         }
     }
 }
-
-
-
 
 // force TS to treat this file as a module
 export default null;

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,0 +1,25 @@
+<script context="module" lang="ts">
+    import type { Load } from '@sveltejs/kit';
+
+    // The whole purpose of this component is to create a dependency on the 
+    // /search.json endpoint via the load function so that /search.json is 
+    // pregenerated during build and bundled as a static json resource
+    export const load: Load = async ({ fetch }) => {
+        const response = await fetch('/search.json');
+        const { blocks } = await response.json();
+
+        return {
+            props: { blocks }
+        }
+    }
+</script>
+
+<script lang="ts">
+    import type { SearchNode } from '$lib/search/types';
+
+    export let blocks : SearchNode[];
+</script>
+
+<pre>
+    {JSON.stringify(blocks)}
+</pre>


### PR DESCRIPTION
- replace the shared worker with a web worker for searching/indexing since web worker has better support for mobile and older browsers
- create a component dependency on /search.json standalone endpoint so that it gets prerendered and served as a static JSON file