### PR TITLE
Corrected code snippet on frontpage

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -83,7 +83,7 @@
 		3
 	)}FullName = $\"{r.FirstName} {r.LastName}\",\n${tab.repeat(
 		3
-	)}Message = \"Welcome to FastEndpoints...\"${tab.repeat(2)}\n${tab.repeat(2)}});\n${tab})\n}`;
+	)}Message = \"Welcome to FastEndpoints...\"${tab.repeat(2)}\n${tab.repeat(2)}});\n${tab}}\n}`;
 
 	export let contributors: Map<string, ContributorInfo>;
 


### PR DESCRIPTION
There's a small typo in the snippet on the frontpage.

```c#
public class MyEndpoint : Endpoint<MyRequest, MyResponse>
{
		public override void Configure()
		{
				Post("/hello/world");
				AllowAnonymous();
		}

		public override async Task HandleAsync(MyRequest r, CancellationToken c)
		{
				await SendAsync(new()
				{
						FullName = $"{r.FirstName} {r.LastName}",
						Message = "Welcome to FastEndpoints..."				
				});
		)
}
```
but it should be
```c#
public class MyEndpoint : Endpoint<MyRequest, MyResponse>
{
		public override void Configure()
		{
				Post("/hello/world");
				AllowAnonymous();
		}

		public override async Task HandleAsync(MyRequest r, CancellationToken c)
		{
				await SendAsync(new()
				{
						FullName = $"{r.FirstName} {r.LastName}",
						Message = "Welcome to FastEndpoints..."				
				});
		}  // <!-- Here
}
```