### PR TITLE
Fixed typo in Problem Details RFC number 8707 > 7807

### DIFF
--- a/src/routes/docs/[...17]configuration-settings.md
+++ b/src/routes/docs/[...17]configuration-settings.md
@@ -216,7 +216,7 @@ app.UseFastEndpoints(c =>
 });
 ```
 
-### RFC8707 Compatible Problem Details
+### RFC7807 Compatible Problem Details
 You can enable RFC compatible error responses like the following:
 ```json
 {


### PR DESCRIPTION
The RFC number for Problem Details is 7807 according to https://datatracker.ietf.org/doc/html/rfc7807 , in the documentation there appears to be a typo and 8707 is used. 