### PR TITLE
Add events and commands testing examples

### DIFF
--- a/src/routes/docs/[...18]integration-unit-testing.md
+++ b/src/routes/docs/[...18]integration-unit-testing.md
@@ -333,6 +333,54 @@ public async Task GetSingleUserById()
 }
 ```
 
+### Events and Commands testing
+
+You can also test event publishing and command execution outside of the Endpoint class. You only need to register fake handlers.
+
+#### Command Execution Test
+```cs
+[Fact]
+public async Task AbilityToFakeTheCommandHandler()
+{
+    // Arrange
+    var command = new TestCommand { FirstName = "a", LastName = "b" };
+
+    var fakeHandler = A.Fake<ICommandHandler<TestCommand, string>>();
+    A.CallTo(() => fakeHandler.ExecuteAsync(A<TestCommand>.Ignored, A<CancellationToken>.Ignored))
+     .Returns(Task.FromResult("Fake Result"));
+     
+    fakeHandler.RegisterForTesting();
+
+    // Act
+    var result = await command.ExecuteAsync();
+
+    // Assert
+    Assert.Equal("Fake Result", result);
+}
+```
+
+
+#### Event Publishing Test
+```cs
+[Fact]
+public async Task AbilityToFakeAnEventHandler()
+{
+    // Arrange
+    var fakeHandler = A.Fake<IEventHandler<NewItemAddedToStock>>();
+
+    A.CallTo(() => fakeHandler.HandleAsync(A<NewItemAddedToStock>.Ignored, A<CancellationToken>.Ignored))
+     .Returns(Task.CompletedTask)
+     .Once();
+
+    new DefaultHttpContext().AddTestServices(sc => sc.AddSingleton(fakeHandler));
+
+    var evnt = new NewItemAddedToStock();
+
+    // Act
+    await evnt.PublishAsync();
+}
+```
+
 ### Unit Test Examples
 
 You can find more unit testing examples [here](https://github.com/FastEndpoints/FastEndpoints/blob/main/Tests/UnitTests/FastEndpoints/WebTests.cs).

--- a/src/routes/docs/[...18]integration-unit-testing.md
+++ b/src/routes/docs/[...18]integration-unit-testing.md
@@ -269,9 +269,7 @@ Starting with .NET 7.0, you have the ability to write unit tests [like this](htt
 
 For passing down route parameters you will have to alter the **HttpContext** by setting them in the **Factory.Create**. See the example below:
 
-#### Endpoint
-
-```cs
+```cs | title=Endpoint.cs
 public class Endpoint : Endpoint<Request, Response>
 {
     public override void Configure()
@@ -306,15 +304,12 @@ public class Response
 }
 ```
 
-#### Test
-
-```cs
+```cs | title=Test.cs
 [Fact]
 public async Task GetSingleUserById()
 {
     // Arrange
-    var ep = Factory.Create<Endpoint>(ctx =>
-      ctx.Request.RouteValues.Add("id", "1"));
+    var ep = Factory.Create<Endpoint>(ctx => ctx.Request.RouteValues.Add("id", "1"));
 
     var req = new Request 
     {
@@ -333,54 +328,56 @@ public async Task GetSingleUserById()
 }
 ```
 
-### Events and Commands testing
+### Units with Command executions or Event publishes
 
-You can also test event publishing and command execution outside of the Endpoint class. You only need to register fake handlers.
+If a code path you're unit testing has command executions or event publishes, fake handlers for those commands/events can be registered as shown below.
 
-#### Command Execution Test
+#### Registering Fake Command Handlers
+
 ```cs
 [Fact]
-public async Task AbilityToFakeTheCommandHandler()
-{
-    // Arrange
-    var command = new TestCommand { FirstName = "a", LastName = "b" };
+public async Task FakeCommandHandlerIsExecuted()
+{    
+    var fakeHandler = A.Fake<ICommandHandler<GetFullNameCommand, string>>();
+    
+    A.CallTo(() => fakeHandler.ExecuteAsync(
+        A<GetFullNameCommand>.Ignored, 
+        A<CancellationToken>.Ignored))
+     .Returns(Task.FromResult("Fake Result"));     
+    
+    fakeHandler.RegisterForTesting(); //register the fake handler
 
-    var fakeHandler = A.Fake<ICommandHandler<TestCommand, string>>();
-    A.CallTo(() => fakeHandler.ExecuteAsync(A<TestCommand>.Ignored, A<CancellationToken>.Ignored))
-     .Returns(Task.FromResult("Fake Result"));
-     
-    fakeHandler.RegisterForTesting();
-
-    // Act
+    //emulating command being executed
+    //typically the unit you're testing will be the executor
+    var command = new GetFullNameCommand { FirstName = "a", LastName = "b" };
     var result = await command.ExecuteAsync();
 
-    // Assert
     Assert.Equal("Fake Result", result);
 }
 ```
 
+#### Registering Fake Event Handlers
 
-#### Event Publishing Test
 ```cs
 [Fact]
-public async Task AbilityToFakeAnEventHandler()
+public async Task FakeEventHandlerIsExecuted()
 {
-    // Arrange
-    var fakeHandler = A.Fake<IEventHandler<NewItemAddedToStock>>();
+    var fakeHandler = new FakeEventHandler();
 
-    A.CallTo(() => fakeHandler.HandleAsync(A<NewItemAddedToStock>.Ignored, A<CancellationToken>.Ignored))
-     .Returns(Task.CompletedTask)
-     .Once();
+    Factory.RegisterTestServices( //register fake handler
+        s =>
+        {
+            s.AddSingleton<IEventHandler<NewItemAddedToStock>>(fakeHandler);
+        });
 
-    new DefaultHttpContext().AddTestServices(sc => sc.AddSingleton(fakeHandler));
+    //emulating event being published
+    //typically the unit you're testing will be the publisher
+    await new NewItemAddedToStock { Name = "xyz" }.PublishAsync();
 
-    var evnt = new NewItemAddedToStock();
-
-    // Act
-    await evnt.PublishAsync();
+    fakeHandler.Name.Should().Be("xyz");
 }
 ```
 
 ### Unit Test Examples
 
-You can find more unit testing examples [here](https://github.com/FastEndpoints/FastEndpoints/blob/main/Tests/UnitTests/FastEndpoints/WebTests.cs).
+More unit testing examples can be found [here](https://github.com/FastEndpoints/FastEndpoints/blob/main/Tests/UnitTests/FastEndpoints/WebTests.cs).


### PR DESCRIPTION
Hello @dj-nitehawk !
I included these examples because it's currently unclear from the documentation how to test whether an event or command has been sent. I have received similar questions from my team on multiple occasions.