### PR TITLE
Fixed SendEventStreamAsync not calling corrent async method

### DIFF
--- a/src/routes/docs/[...16]server-sent-events.md
+++ b/src/routes/docs/[...16]server-sent-events.md
@@ -21,7 +21,7 @@ public class EventStream : EndpointWithoutRequest
     public override async Task HandleAsync(CancellationToken ct)
     {
         //simply provide any IAsyncEnumerable<T> as argument
-        await SendEventStream("my-event", GetDataStream(ct), ct);
+        await SendEventStreamAsync("my-event", GetDataStream(ct), ct);
     }
 
     private async IAsyncEnumerable<object> GetDataStream([EnumeratorCancellation] CancellationToken ct)


### PR DESCRIPTION
Simple fix in example to call correct SendEventStreamAsync instead of SendEventStream method.