### PR TITLE
fix SendCode method name mismatch with example

### DIFF
--- a/src/routes/docs/[...20]misc-conveniences.md
+++ b/src/routes/docs/[...20]misc-conveniences.md
@@ -155,7 +155,7 @@ If the provided response sending methods are not sufficient, you can easily crea
 ```cs
 public static class EndpointExtensions
 {
-    public static Task SendCode(this IEndpoint ep, int statusCode, CancellationToken ct = default)
+    public static Task SendStatusCode(this IEndpoint ep, int statusCode, CancellationToken ct = default)
     {
         ep.HttpContext.MarkResponseStart(); //don't forget to always do this
         ep.HttpContext.Response.StatusCode = statusCode;


### PR DESCRIPTION
The implementation used `SendCode` but the example below uses `SendStatusCode`.