### PR TITLE
docs: Update Scalar Link

### DIFF
--- a/src/routes/docs/[...10]swagger-support.md
+++ b/src/routes/docs/[...10]swagger-support.md
@@ -30,7 +30,7 @@ app.UseFastEndpoints()
 app.Run();
 ```
 
-You can then visit **/swagger** for the SwaggerUI or **/swagger/v1/swagger.json** to see the generated Swagger document. If you prefer to use [Scalar](https://github.com/scalar/scalar/tree/main/packages/scalar.aspnetcore) for API visualization instead of SwaggerUI, have a look at [this gist](https://gist.github.com/dj-nitehawk/c7052f01f3f650e67fb6782c84d3b5f0).
+You can then visit **/swagger** for the SwaggerUI or **/swagger/v1/swagger.json** to see the generated Swagger document. If you prefer to use [Scalar](https://github.com/scalar/scalar/tree/main/integrations/aspnetcore) for API visualization instead of SwaggerUI, have a look at [this gist](https://gist.github.com/dj-nitehawk/c7052f01f3f650e67fb6782c84d3b5f0).
 
 :::admonition type="warning"
 


### PR DESCRIPTION
Hey,

Firstly, thanks for mentioning Scalar in your documentation!
I noticed that the link to Scalar is dead because we updated our project structure a bit! This PR updates the link.

**Off-topic:**
We could also extend our Scalar Documentation with a section on how to set up Scalar with `FastEndpoints`. I totally forgot to do so because I didn't work with `FastEndpoints` _yet_.